### PR TITLE
Issue: empty string in model / stringRep

### DIFF
--- a/blueprints/mu-resource/files/app/models/__name__.js
+++ b/blueprints/mu-resource/files/app/models/__name__.js
@@ -3,7 +3,7 @@
 export default Model.extend({
   // A string representation of this model, based on its attributes.
   // This is what mu-cl-resources uses to search on, and how the model will be presented while editing relationships.
-  stringRep: Ember.computed.collect.apply(this,['id',<%="'" + attributes.map( function(attribute) {return attribute.name}).join("', '") + "'"%>]),
+  stringRep: Ember.computed.collect.apply(this,[<%="'" + ["id"].concat(attributes.map( function(attribute) {return attribute.name})).join("', '") + "'"%>]),
 
   <%= attrs %>
 });


### PR DESCRIPTION
If there are no attributes, the generated code was `stringRep: Ember.computed.collect.apply(this,['id',''])`

This was fixed to generate `stringRep: Ember.computed.collect.apply(this,['id'])`