### PR TITLE
Plural names fix for has-many relationships

### DIFF
--- a/blueprints/mu-resource/index.js
+++ b/blueprints/mu-resource/index.js
@@ -66,9 +66,8 @@ module.exports = {
 
       var attr;
       if (/has-many/.test(dasherizedType)) {
-        var camelizedNamePlural = inflection.pluralize(camelizedName);
         attr = dsAttr(dasherizedForeignModelSingular, dasherizedType, camelizedInverseName);
-        attrs.push(camelizedNamePlural + ': ' + attr);
+        attrs.push(camelizedName + ': ' + attr);
         shouldImportHasMany = true;
       } else if (/belongs-to/.test(dasherizedType)) {
         attr = dsAttr(dasherizedForeignModel, dasherizedType, camelizedInverseName);

--- a/blueprints/mu-resource/index.js
+++ b/blueprints/mu-resource/index.js
@@ -66,6 +66,7 @@ module.exports = {
 
       var attr;
       if (/has-many/.test(dasherizedType)) {
+        // var camelizedNamePlural = inflection.pluralize(camelizedName);
         attr = dsAttr(dasherizedForeignModelSingular, dasherizedType, camelizedInverseName);
         attrs.push(camelizedName + ': ' + attr);
         shouldImportHasMany = true;

--- a/blueprints/mu-resource/index.js
+++ b/blueprints/mu-resource/index.js
@@ -66,7 +66,6 @@ module.exports = {
 
       var attr;
       if (/has-many/.test(dasherizedType)) {
-        // var camelizedNamePlural = inflection.pluralize(camelizedName);
         attr = dsAttr(dasherizedForeignModelSingular, dasherizedType, camelizedInverseName);
         attrs.push(camelizedName + ': ' + attr);
         shouldImportHasMany = true;


### PR DESCRIPTION
When you ran a command with generating relationships, the mu-resource generator renamed the "single" named relations to plural. For example: 

```
ember g mu-resource job title:language-string-set worker:has-many:person~job  
```
This command would generate:

``` js
import Ember from 'ember';
import Model from 'ember-data/model';
import attr from 'ember-data/attr';
import { hasMany } from 'ember-data/relationships';

export default Model.extend({
  // A string representation of this model, based on its attributes.
  // This is what mu-cl-resources uses to search on, and how the model will be presented while editing relationships.
  stringRep: Ember.computed.collect.apply(this,['id','title']),

  title: attr('language-string-set'),
  workers: hasMany('person', {inverse: 'job'})
});
```

Where the `worker` was renamed to `workers`. Vincent (@VulumeCode) fixed this on our gitlab. I just took the commits from there and pushed it here, as we cannot do pull requests from gitlab to github.